### PR TITLE
Unicode emoji changed

### DIFF
--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -3,7 +3,7 @@ const { inspect } = require('util')
 const { LOG_INFO_CHANNEL } = process.env
 
 const emodji = {
-  white: {
+  black: {
     rook: '♜',
     knight: '♞',
     bishop: '♝',
@@ -11,7 +11,7 @@ const emodji = {
     king: '♚',
     pawn: '♟',
   },
-  black: {
+  white: {
     rook: '♖',
     knight: '♘',
     bishop: '♗',


### PR DESCRIPTION
| Name | Symbol | Code point | HTML (decimal) | HTML (hex) |
| --- | :---: | :---: | :---: | :---: |
| white chess king   | ♔ | `U+2654` | `&#9812;` | `&#x2654;` |
| white chess queen	 | ♕ | `U+2655` | `&#9813;` | `&#x2655;` |
| white chess rook   | ♖ | `U+2656` | `&#9814;` | `&#x2656;` |
| white chess bishop | ♗ | `U+2657` | `&#9815;` | `&#x2657;` |
| white chess knight | ♘ | `U+2658` | `&#9816;` | `&#x2658;` |
| white chess pawn   | ♙ | `U+2659` | `&#9817;` | `&#x2659;` |
| black chess king   | ♚ | `U+265A` | `&#9818;` | `&#x265A;` |
| black chess queen	 | ♛ | `U+265B` | `&#9819;` | `&#x265B;` |
| black chess rook   | ♜ | `U+265C` | `&#9820;` | `&#x265C;` |
| black chess bishop | ♝ | `U+265D` | `&#9821;` | `&#x265D;` |
| black chess knight | ♞ | `U+265E` | `&#9822;` | `&#x265E;` |
| black chess pawn   | ♟ | `U+265F` | `&#9823;` | `&#x265F;` |

https://en.wikipedia.org/wiki/Chess_symbols_in_Unicode
